### PR TITLE
Updated plots for GWAS results and merge results

### DIFF
--- a/pooled_phenotype_analyses/pooled_lipids_phenotypes.ipynb
+++ b/pooled_phenotype_analyses/pooled_lipids_phenotypes.ipynb
@@ -1080,6 +1080,8 @@
     "    num_in_common_results = nrow(in_common_results)\n",
     "    result_cor = cor(in_common_results$beta_AoU_UKB, in_common_results$beta_Hindy)\n",
     "    \n",
+    "    options(repr.plot.width = 10, repr.plot.height = 10)\n",
+    "\n",
     "    in_common_results %>%\n",
     "    ggplot(aes(x = beta_Hindy, y = beta_AoU_UKB)) +\n",
     "        geom_point(alpha = .5) +\n",
@@ -1147,6 +1149,8 @@
     "    num_in_common_results = nrow(in_common_results)\n",
     "    result_cor = cor(in_common_results$beta_AoU_UKB, in_common_results$beta_selvaraj)\n",
     "    \n",
+    "    options(repr.plot.width = 10, repr.plot.height = 10)\n",
+    "\n",
     "    in_common_results %>%\n",
     "    ggplot(aes(x = beta_selvaraj, y = beta_AoU_UKB)) +\n",
     "        geom_point(alpha = .5) +\n",
@@ -1164,6 +1168,64 @@
     "            axis.title.y=element_text(size=14),\n",
     "        ) +\n",
     "        labs(title = str_glue('{aou_ukb_lipid} GWAS result comparison to {num_selvaraj_results}\\nsignificant RSID from Selvaraj et al. 2021'),\n",
+    "             caption = PLOT_SUBTITLE)\n",
+    "\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comparison Hindy vs. Selvaraj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "map2(aou_ukb_lipids, hindy_lipids, function(aou_ukb_lipid, hindy_lipid) {\n",
+    "    hindy_results = UKB_lipid_exome_GWAS_summary %>%\n",
+    "        filter(Ancestry == 'Overall' & Trait == hindy_lipid) %>%\n",
+    "        select(RSID, beta_Hindy=BETA_FE)\n",
+    "\n",
+    "    selvaraj_results = TOPMED_lipid_GWAS_summary %>%\n",
+    "        filter(Lipid == aou_ukb_lipid) %>%\n",
+    "        select(RSID, beta_selvaraj=BETA)\n",
+    "\n",
+    "    in_common_results = inner_join(\n",
+    "        hindy_results,\n",
+    "        selvaraj_results\n",
+    "    )\n",
+    "    \n",
+    "    num_hindy_results = nrow(hindy_results)\n",
+    "    num_selvaraj_results = nrow(selvaraj_results)\n",
+    "    num_in_common_results = nrow(in_common_results)\n",
+    "    result_cor = cor(in_common_results$beta_selvaraj, in_common_results$beta_Hindy)\n",
+    "    \n",
+    "    options(repr.plot.width = 10, repr.plot.height = 10)\n",
+    "\n",
+    "    in_common_results %>%\n",
+    "    ggplot(aes(x = beta_Hindy, y = beta_selvaraj)) +\n",
+    "        geom_point(alpha = .5) +\n",
+    "        annotate(geom = 'text',\n",
+    "                 x = max(in_common_results$beta_Hindy),\n",
+    "                 y = min(in_common_results$beta_selvaraj),\n",
+    "                 hjust = 'right',\n",
+    "                 vjust = -1,\n",
+    "                 color = 'dark blue', \n",
+    "                 size = 6,\n",
+    "                 label = c(str_glue('correlation: {round(result_cor, digits = 3)}\\nN = {num_in_common_results}'))) +\n",
+    "        geom_abline() +\n",
+    "        theme(\n",
+    "            axis.title.x=element_text(size=14),\n",
+    "            axis.title.y=element_text(size=14),\n",
+    "        ) +\n",
+    "        labs(title = str_glue('{aou_ukb_lipid} GWAS result comparison between {num_hindy_results} significant RSID\n",
+    "from Hindy et al. 2021 and {num_selvaraj_results} significant RSID from\n",
+    "Selvaraj et al. 2021'),\n",
     "             caption = PLOT_SUBTITLE)\n",
     "\n",
     "})"
@@ -1245,7 +1307,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "allele_freq %>% filter(is.na(AF))"
+    "allele_freq %>% filter(is.na(allele_frequency))"
    ]
   },
   {
@@ -1278,7 +1340,29 @@
     "options(repr.plot.width = 16, repr.plot.height = 8)\n",
     "\n",
     "allele_freq %>%\n",
-    "    ggplot(aes(x = AF)) +\n",
+    "    filter(allele_frequency < .01) %>%\n",
+    "    ggplot(aes(x = allele_frequency)) +\n",
+    "    geom_histogram() +\n",
+    "    facet_grid(cols = vars(variant_set)) +\n",
+    "    scale_y_log10(labels=comma) +\n",
+    "    theme(\n",
+    "        axis.title.x=element_text(size=14),\n",
+    "        axis.title.y=element_text(size=14),\n",
+    "    ) +\n",
+    "    labs(title = str_glue('Histogram of allele frequencies MAF < 1% [y-axis in log scale]'),\n",
+    "         caption = PLOT_SUBTITLE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "options(repr.plot.width = 16, repr.plot.height = 8)\n",
+    "\n",
+    "allele_freq %>%\n",
+    "    ggplot(aes(x = allele_frequency)) +\n",
     "    geom_histogram() +\n",
     "    facet_grid(cols = vars(variant_set)) +\n",
     "    scale_y_continuous(labels=comma)"
@@ -1293,7 +1377,7 @@
     "options(repr.plot.width = 16, repr.plot.height = 8)\n",
     "\n",
     "allele_freq %>%\n",
-    "    ggplot(aes(x = variant_set, y = AF)) +\n",
+    "    ggplot(aes(x = variant_set, y = allele_frequency)) +\n",
     "    geom_boxplot() +\n",
     "    scale_y_log10()"
    ]


### PR DESCRIPTION
* updated the GWAS comparison plots to include titles, axis labels, and some annotations.
* added plots to compare GWAS results from Hindy et al. 2021 to Selvarag et al. 2021
* added histograms for allele frequency distributions of merged, AoU-only, and UKB-only

See the updated plots [here](https://preprod-workbench.researchallofus.org/workspaces/aou-rw-preprod-acef10ae/ukb7089pooledanalysisofallofusandukbiobankgenomicdata/notebooks/pooled_lipids_phenotypes.ipynb?playgroundMode=true).