### PR TITLE
Remove unnecessary cell metadata.

### DIFF
--- a/aou_workbench_siloed_analyses/5_aou_plot_results.ipynb
+++ b/aou_workbench_siloed_analyses/5_aou_plot_results.ipynb
@@ -581,9 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "map(LIPIDS, function(lipid) {\n",
@@ -728,9 +726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "map(LIPIDS, function(lipid) {\n",
@@ -897,9 +893,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "map(LIPIDS, function(lipid) {\n",


### PR DESCRIPTION
Checking in this change so that the file no longer looks like it has changes according to `git status` when it is actually unchanged. nbstripout keeps trying to edit this file and this is the change it wants to make. 