### PR TITLE
Update REGENIE to work-around errors.

### DIFF
--- a/aou_workbench_pooled_analyses/11_batch_regenie_gwas.ipynb
+++ b/aou_workbench_pooled_analyses/11_batch_regenie_gwas.ipynb
@@ -56,6 +56,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <b>Note:</b> REGENIE 2.2.4 was use for the lipids GWAS, but we upgraded to 3.1.1 for the batch GWAS due to error <kbd>ERROR: logistic regression did not converge for phenotype is_aou. Perhaps increase --niter?</kbd> on chromosome 10.\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -63,7 +72,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "REGENIE_VERSION=v2.2.4\n",
+    "REGENIE_VERSION=v3.1.1\n",
     "rm regenie.zip\n",
     "curl -L -o regenie.zip \"https://github.com/rgcgithub/regenie/releases/download/${REGENIE_VERSION}/regenie_${REGENIE_VERSION}.gz_x86_64_Linux.zip\"\n",
     "unzip -o regenie.zip"
@@ -75,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!./regenie_v2.2.4.gz_x86_64_Linux --help | head"
+    "!./regenie_v3.1.1.gz_x86_64_Linux --help | head"
    ]
   },
   {
@@ -171,12 +180,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <b>Note:</b> Compared to the pooled lipids GWAS, added parameter <kbd>--loocv</kbd> to address error <kbd>ERROR: one of the folds has only cases/controls for phenotype 'is_aou'. Either use smaller #folds (option --cv) or use LOOCV (option --loocv).</kbd>\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!./regenie_v2.2.4.gz_x86_64_Linux \\\n",
+    "!./regenie_v3.1.1.gz_x86_64_Linux \\\n",
     "    --step 1 \\\n",
     "    --bgen {LOCAL_MERGED_BGEN} \\\n",
     "    --ref-first \\\n",
@@ -192,10 +210,7 @@
     "    --keep {LOCAL_STEP1_VARIANT_QC_ID} \\\n",
     "    --bsize 1000 \\\n",
     "    --verbose \\\n",
-    "    --out {OUTPUT_FILENAME_PREFIX}_regenie_step1\n",
-    "\n",
-    "# setting memory...ERROR: one of the folds has only cases/controls for phenotype 'is_aou'. \n",
-    "# Either use smaller #folds (option --cv) or use LOOCV (option --loocv)."
+    "    --out {OUTPUT_FILENAME_PREFIX}_regenie_step1"
    ]
   },
   {
@@ -236,12 +251,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <b>Note:</b> Not using a Firth logistic regression model to address error <kbd>ERROR: Firth penalized logistic regression failed to converge for all phenotypes. Try decreasing the maximum step size using `--maxstep-null` (currently=5) and increasing the maximum number of iterations using `--maxiter-null` (currently=5000).</kbd>\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!./regenie_v2.2.4.gz_x86_64_Linux \\\n",
+    "!./regenie_v3.1.1.gz_x86_64_Linux \\\n",
     "    --step 2 \\\n",
     "    --bgen {LOCAL_MERGED_BGEN} \\\n",
     "    --ref-first \\\n",
@@ -249,7 +273,6 @@
     "    --phenoFile {LOCAL_GWAS_PHENOTYPES} \\\n",
     "    --phenoColList is_aou,is_ukb \\\n",
     "    --bt \\\n",
-    "    --firth --approx --pThresh 0.01 \\\n",
     "    --covarFile {LOCAL_GWAS_PHENOTYPES} \\\n",
     "    --catCovarList sex_at_birth \\\n",
     "    --covarColList age,age2,PC1,PC2,PC3,PC4,PC5,PC6,PC7,PC8,PC9,PC10 \\\n",


### PR DESCRIPTION
For comparison, see:
* run of REGENIE 2.2.4 https://preprod-workbench.researchallofus.org/workspaces/aou-rw-preprod-a60bccab/ukbaoualpha3pooledanalysisofallofusandukbiobankgenomicdata/notebooks/preview/11_batch_regenie_gwas_20220413_004319.ipynb 
* run of REGENIE 3.1.1 https://preprod-workbench.researchallofus.org/workspaces/aou-rw-preprod-a60bccab/ukbaoualpha3pooledanalysisofallofusandukbiobankgenomicdata/notebooks/preview/11_batch_regenie_gwas_20220507_002448.ipynb